### PR TITLE
Added onCompleted callback

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { FormikHelpers, FormikConfig } from "formik";
+import { FormikConfig, FormikHelpers } from "formik";
 import { GraphQLError } from "graphql";
 
 /**
@@ -16,12 +16,16 @@ export interface ValidationError extends GraphQLError {
 /**
  * The function that is called when the form is submitted.
  */
-export type SubmitHandler<T> = (data: T, actions: FormikHelpers<T>) => any;
+export type SubmitHandler<T, R = any> = (
+  data: T,
+  actions: FormikHelpers<T>
+) => R;
 
 /**
  * Options the can be passed to `useSubmit`.
  */
-export interface SubmitOptions {
+export interface SubmitOptions<T> {
+  onCompleted?: (result: T) => void;
   getStatus?: (error: Error) => any;
   getErrors?: (error: Error) => Record<string, string>;
 }

--- a/src/useSubmit.ts
+++ b/src/useSubmit.ts
@@ -1,17 +1,18 @@
-import { useCallback } from "react";
 import { isApolloError } from "apollo-client";
+import { useCallback } from "react";
+import { getStatusFromError, getValidationErrors } from "./errors";
 import { SubmitHandler, SubmitOptions } from "./types";
-import { getValidationErrors, getStatusFromError } from "./errors";
 
 /**
  * Wraps form submission with loading/error handling.
  */
-export const useSubmit = <T>(
-  onSubmit: SubmitHandler<T>,
+export const useSubmit = <T, R = any>(
+  onSubmit: SubmitHandler<T, Promise<R>>,
   {
+    onCompleted,
     getStatus = getStatusFromError,
     getErrors = getValidationErrors
-  }: SubmitOptions = {}
+  }: SubmitOptions<R> = {}
 ): SubmitHandler<T> => {
   return useCallback(
     async (values, form) => {
@@ -20,6 +21,7 @@ export const useSubmit = <T>(
       try {
         const result = await onSubmit(values, form);
         form.setSubmitting(false);
+        onCompleted && onCompleted(result);
         return result;
       } catch (error) {
         if (!isApolloError(error)) {


### PR DESCRIPTION
This PR adds a `onCompleted` callback to the options object supplied to `useSubmit`.
It receives whatever is returned from `onSubmit`.

### Motivation
Anything within your `onSubmit` callback, that caused `Formik` to be unmouted resulted in a `state update on unmounted component` error
See: #1 

### Before
In order to prevent above situation, you had to wrap your callback again like this:
```ts
const submitForm = useSubmit((data: SomeType) => mutate({
  variables: {
    input: data,
  }
}));

const handleSubmit = useCallback(
  async (data: SomeType, form: FormikHelpers<SomeType>) => {
    const mutationResult: SomeMutationResult | null | undefined = await submitForm(data, form);
    if (mutationResult && mutationResult.id) {
      history.push(`/entities/${mutationResult.id}`);
    }
  },
  [history, submitForm],
);
```
### After
Now, you can just supply a `onCompleted` callback to do the same (types are inferred properly)
```ts
const handleSubmit = useSubmit(
  (data: SomeType) =>
    mutate({
      variables: {
        input: data,
      }
    }),
  {
    onCompleted: ({ data }) => {
      if (data && data.mutationResult) {
        history.push(`/entities/${data.mutationResult.id}`);
      }
    },
  },
);
```
